### PR TITLE
add python formatting rules to `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,24 +8,68 @@ version = "0.1.0"
 description = "Scaling RL Environments for Terminal Agents"
 requires-python = ">=3.12"
 dependencies = [
-    "pydantic",
-    "tenacity",
-    "tqdm",
-    "openai",
-    "datasets",
-    "transformers",
+  "pydantic",
+  "tenacity",
+  "tqdm",
+  "openai",
+  "datasets",
+  "transformers",
 ]
 
 [project.optional-dependencies]
-harbor = [
-    "harbor",
-]
-train = [
-    "ray",
-    "hydra-core",
-    "omegaconf",
-]
+harbor = ["harbor"]
+train = ["ray", "hydra-core", "omegaconf"]
 
 [tool.setuptools.packages.find]
 where = ["."]
-include = ["endless_harbor", "endless.*", "generator", "generator.*", "train", "train.*"]
+include = [
+  "endless_harbor",
+  "endless.*",
+  "generator",
+  "generator.*",
+  "train",
+  "train.*",
+]
+
+
+ignore = [
+  "E501", # Never enforce `E501` (line length violations). Sometimes our prompts are really long.
+  "E731", # 2+ people agree lambda functions are helpful, so ignore complaints about assigning lambda functions to variables
+  "N999", # Invalid module due to hyphen. A lot of our modules contains hyphens.
+]
+select = [
+  "C",   # Convention violations, like coding standards issues (PEP8)
+  "E",   # Errors that could cause exceptions or major functionality issues
+  "F",   # Flaws in type annotations
+  "I",   # Import-related linting issues
+  "W",   # Warnings for stylistic or minor programming issues
+  "PL",  # PyLint checks, including unused function variables
+  "N",   # Naming convention checks (PEP8)
+  "D",   # Docstring style checks, often based on Google's style guidelines
+  "UP",  # Checks for deprecated Python features that could be upgraded
+  "FIX", # Reminder tags for TODOs and FIXMEs in the code
+]
+pydocstyle.convention = "google"
+
+# Ignore import violations in all `__init__.py` files.
+[tool.ruff.lint.per-file-ignores]
+"__init__.py" = ["E402", "F401", "F403", "F811"]
+
+
+[tool.ruff.format]
+# Like Black, use double quotes for strings.
+quote-style = "double"
+
+# Like Black, indent with spaces, rather than tabs.
+indent-style = "space"
+
+
+# Like Black, respect magic trailing commas.
+skip-magic-trailing-comma = false
+
+# Like Black, automatically detect the appropriate line ending.
+line-ending = "auto"
+
+[tool.isort]
+profile = "black"
+lines_after_imports = 2


### PR DESCRIPTION
As title.

Please install the linter tool Ruff locally in your environment to reflect the rules in toml file on the code base. 